### PR TITLE
feat: implement demo mode with mock data and backend status management

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import * as MockData from "./mock-data";
+import { useBackendStatus, useDemoReviewQueue } from "./backend-status";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
 
@@ -8,8 +9,7 @@ function shouldUseMockData(): boolean {
 
   // Check if backend status store indicates disconnection
   try {
-    const backendStatusModule = require("./backend-status");
-    const status = backendStatusModule.useBackendStatus.getState();
+    const status = useBackendStatus.getState();
     return !status.isConnected;
   } catch {
     return false;
@@ -297,8 +297,7 @@ export async function submitFeedback(records: FeedbackPayload[]): Promise<void> 
     // Remove cases from demo queue
     if (typeof window !== "undefined") {
       try {
-        const backendStatusModule = require("./backend-status");
-        const demoQueue = backendStatusModule.useDemoReviewQueue.getState();
+        const demoQueue = useDemoReviewQueue.getState();
         records.forEach((record) => {
           demoQueue.removeCase(record.request_id);
         });
@@ -337,8 +336,7 @@ export async function predictSingle(instance: JobPostingInput): Promise<Predicti
   if (shouldUseMockData() && prediction.decision === "review") {
     if (typeof window !== "undefined") {
       try {
-        const backendStatusModule = require("./backend-status");
-        const demoQueue = backendStatusModule.useDemoReviewQueue.getState();
+        const demoQueue = useDemoReviewQueue.getState();
         demoQueue.addCase(prediction, instance);
       } catch (e) {
         console.error("Failed to add case to demo queue:", e);


### PR DESCRIPTION
This pull request refactors how the `useBackendStatus` and `useDemoReviewQueue` hooks are imported and used in the `frontend/src/lib/api.ts` file. Instead of requiring these modules dynamically, the hooks are now imported at the top of the file and used directly, leading to cleaner and more consistent code.

**Refactoring of backend status and demo queue usage:**

* Replaced dynamic `require` calls with direct imports for `useBackendStatus` and `useDemoReviewQueue` at the top of `api.ts`, improving code clarity and reliability.
* Updated all usages of `useBackendStatus` and `useDemoReviewQueue` in `shouldUseMockData`, `submitFeedback`, and `predictSingle` to reference the directly imported hooks instead of accessing them via a dynamically required module. [[1]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8L11-R12) [[2]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8L300-R300) [[3]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8L340-R339)