### PR TITLE
feat: add accessible image lightbox with keyboard and focus support

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,6 +787,11 @@ docker-compose up --build
       </p>
     </div>
   </footer>
+
+  <div class="lightbox" aria-hidden="true" role="dialog" aria-label="Expanded image preview">
+    <button class="lightbox-close" type="button" aria-label="Close image">X</button>
+    <img src="" alt="" />
+  </div>
   
   <!-- Scripts -->
   <script src="packages/script.js"></script>

--- a/packages/script.js
+++ b/packages/script.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initializeThemeToggle();
   initializeBackToTop();
   initializeCopyButtons();
+  initializeImageLightbox();
   initializeActiveNavigation();
   initializeHamburgerMenu();
 });
@@ -321,6 +322,66 @@ function initializeCopyButtons() {
         }, 2000);
       });
     });
+  });
+}
+
+// ============================================
+// Image Lightbox
+// ============================================
+function initializeImageLightbox() {
+  const lightbox = document.querySelector('.lightbox');
+  if (!lightbox) return;
+
+  const lightboxImage = lightbox.querySelector('img');
+  const closeButton = lightbox.querySelector('.lightbox-close');
+  let lastFocusedElement = null;
+
+  const openLightbox = (img) => {
+    lastFocusedElement = document.activeElement;
+    const source = img.currentSrc || img.src;
+    lightboxImage.src = source;
+    lightboxImage.alt = img.alt || 'Expanded image preview';
+    lightbox.classList.add('active');
+    lightbox.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('lightbox-open');
+    closeButton.focus();
+  };
+
+  const closeLightbox = () => {
+    lightbox.classList.remove('active');
+    lightbox.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('lightbox-open');
+    lightboxImage.src = '';
+    lightboxImage.alt = '';
+    if (lastFocusedElement) {
+      lastFocusedElement.focus();
+    }
+  };
+
+  document.querySelectorAll('.screenshot img').forEach((img) => {
+    img.setAttribute('role', 'button');
+    img.setAttribute('tabindex', '0');
+    img.addEventListener('click', () => openLightbox(img));
+    img.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        openLightbox(img);
+      }
+    });
+  });
+
+  closeButton.addEventListener('click', closeLightbox);
+
+  lightbox.addEventListener('click', (event) => {
+    if (event.target === lightbox) {
+      closeLightbox();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && lightbox.classList.contains('active')) {
+      closeLightbox();
+    }
   });
 }
 

--- a/packages/styles.css
+++ b/packages/styles.css
@@ -669,6 +669,63 @@ tr:hover {
   width: 100%;
   height: auto;
   display: block;
+  cursor: zoom-in;
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 2000;
+}
+
+.lightbox.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.lightbox img {
+  max-width: min(1200px, 92vw);
+  max-height: 86vh;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: 0.75rem;
+  border: 1px solid var(--dark-border);
+  box-shadow: var(--shadow-xl);
+  background: var(--dark-bg);
+}
+
+.lightbox-close {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid var(--dark-border);
+  background: rgba(15, 23, 42, 0.9);
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.lightbox-close:hover {
+  transform: scale(1.05);
+  border-color: var(--primary-color);
+}
+
+body.lightbox-open {
+  overflow: hidden;
 }
 
 /* Footer */


### PR DESCRIPTION
This pull request adds an accessible image lightbox feature to the site, allowing users to click on images within `.screenshot` containers to view them in an enlarged modal overlay. The implementation includes markup, JavaScript logic, and styling for the lightbox, as well as accessibility enhancements.

**New Image Lightbox Feature:**

* Added a `.lightbox` modal to `index.html` for expanded image previews, including a close button and appropriate ARIA attributes for accessibility.
* Implemented the `initializeImageLightbox` function in `packages/script.js` to handle opening, closing, keyboard navigation (Enter, Space, Escape), focus management, and accessibility roles for the lightbox and images.
* Registered the new lightbox initialization in the DOMContentLoaded event in `packages/script.js`.

**Styling and Usability Enhancements:**

* Added CSS in `packages/styles.css` for the `.lightbox` overlay, modal image, close button, and body state to ensure proper appearance, transitions, and scroll locking.
* Updated image styling to show a zoom-in cursor on hover, indicating interactivity.