### PR TITLE
fix: remove pip cache configuration from docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,8 +28,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by removing the pip caching configuration from the Python setup step in `.github/workflows/docker-publish.yml`. This simplifies the workflow and may help avoid issues related to dependency caching.