### PR TITLE
fix: update generative model version to gemini-2.5-flash for assistant

### DIFF
--- a/src/spot_scam/api/app.py
+++ b/src/spot_scam/api/app.py
@@ -363,12 +363,12 @@ async def chat_stream(request: ChatRequest):
         assistant_instruction = "\n".join(system_parts)
 
         assistant_model = genai.GenerativeModel(
-            "gemini-2.0-flash-lite",
+            "gemini-2.5-flash",
             system_instruction=assistant_instruction,
         )
 
         classifier_model = genai.GenerativeModel(
-            "gemini-2.0-flash-lite",
+            "gemini-2.5-flash",
             system_instruction=(
                 "You determine whether a message contains information about a job posting. "
                 "Respond ONLY with JSON using this schema: "


### PR DESCRIPTION
This pull request updates the generative models used in the `chat_stream` endpoint to leverage a newer version. The changes ensure that both the assistant and classifier components use the latest model for improved performance and capabilities.

Model version upgrades:

* In `src/spot_scam/api/app.py`, the `assistant_model` and `classifier_model` are both updated to use `"gemini-2.5-flash"` instead of `"gemini-2.0-flash-lite"` within the `chat_stream` function.