### PR TITLE
Enhance wiki page styling with animations, code blocks, and spacing

### DIFF
--- a/packages/script.js
+++ b/packages/script.js
@@ -293,51 +293,77 @@ function initializeBackToTop() {
 }
 
 // ============================================
-// Copy Code Buttons
+// macOS-style Code Windows with Copy Buttons
 // ============================================
 function initializeCopyButtons() {
+  const copyIcon = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+  const checkIcon = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+
   document.querySelectorAll('pre').forEach((block) => {
-    const button = document.createElement('button');
-    button.className = 'copy-btn';
-    button.textContent = 'Copy';
-    button.style.cssText = `
-      position: absolute;
-      top: 0.5rem;
-      right: 0.5rem;
-      padding: 0.5rem 1rem;
-      background: var(--primary-color);
-      color: white;
-      border: none;
-      border-radius: 0.5rem;
-      cursor: pointer;
-      font-size: 0.8rem;
-      font-weight: 600;
-      opacity: 0;
-      transition: all 0.3s ease;
-    `;
+    // Skip if already wrapped or inside mermaid
+    if (block.closest('.code-window') || block.closest('.mermaid')) return;
 
-    block.style.position = 'relative';
-    block.appendChild(button);
+    const codeText = (block.querySelector('code')?.textContent || block.textContent).trim();
 
-    block.addEventListener('mouseenter', () => {
-      button.style.opacity = '1';
-    });
+    // Detect a title from content
+    let title = 'Terminal';
+    if (codeText.startsWith('spot-the-scam') || codeText.match(/^[├└│]/m)) {
+      title = 'Project Structure';
+    } else if (codeText.startsWith('git clone')) {
+      title = 'Terminal — git';
+    } else if (codeText.startsWith('docker') || codeText.includes('docker-compose')) {
+      title = 'Terminal — docker';
+    } else if (codeText.startsWith('cd frontend') || codeText.includes('npm ')) {
+      title = 'Terminal — npm';
+    } else if (codeText.includes('python') || codeText.includes('pip ')) {
+      title = 'Terminal — python';
+    }
 
-    block.addEventListener('mouseleave', () => {
-      button.style.opacity = '0';
-    });
+    // Build wrapper
+    const wrapper = document.createElement('div');
+    wrapper.className = 'code-window';
 
-    button.addEventListener('click', () => {
+    // Header
+    const header = document.createElement('div');
+    header.className = 'code-window-header';
+
+    // Traffic-light dots
+    const dots = document.createElement('div');
+    dots.className = 'code-window-dots';
+    dots.innerHTML =
+      '<span class="code-window-dot code-window-dot--close"></span>' +
+      '<span class="code-window-dot code-window-dot--minimize"></span>' +
+      '<span class="code-window-dot code-window-dot--maximize"></span>';
+
+    // Title
+    const titleEl = document.createElement('span');
+    titleEl.className = 'code-window-title';
+    titleEl.textContent = title;
+
+    // Copy button
+    const copyBtn = document.createElement('button');
+    copyBtn.className = 'copy-btn';
+    copyBtn.innerHTML = copyIcon + ' Copy';
+    copyBtn.addEventListener('click', () => {
       const code = block.querySelector('code')?.textContent || block.textContent;
       navigator.clipboard.writeText(code).then(() => {
-        button.textContent = 'Copied!';
-        button.style.background = 'var(--secondary-color)';
+        copyBtn.innerHTML = checkIcon + ' Copied!';
+        copyBtn.classList.add('copied');
         setTimeout(() => {
-          button.textContent = 'Copy';
-          button.style.background = 'var(--primary-color)';
+          copyBtn.innerHTML = copyIcon + ' Copy';
+          copyBtn.classList.remove('copied');
         }, 2000);
       });
     });
+
+    header.appendChild(dots);
+    header.appendChild(titleEl);
+    header.appendChild(copyBtn);
+
+    // Wrap the pre element
+    block.parentNode.insertBefore(wrapper, block);
+    wrapper.appendChild(header);
+    wrapper.appendChild(block);
   });
 }
 

--- a/packages/styles.css
+++ b/packages/styles.css
@@ -319,17 +319,50 @@ body {
 }
 
 @media (max-width: 768px) {
-  .bg-orb {
-    opacity: 0.66;
+  /* Reduce blur cost on the aurora layer and slow it down */
+  .animated-background::before {
+    filter: blur(30px) saturate(120%);
+    animation-duration: 30s;
   }
 
+  /* Disable grid pulse animation entirely */
+  .animated-background::after {
+    animation: none;
+    opacity: 0.24;
+  }
+
+  /* Remove expensive glow animations, keep only a slow float */
+  .bg-orb {
+    opacity: 0.5;
+    will-change: auto;
+  }
+
+  .bg-orb-1 {
+    animation: orbFloatA 24s ease-in-out infinite;
+  }
+
+  .bg-orb-2 {
+    animation: orbFloatB 22s ease-in-out infinite;
+  }
+
+  .bg-orb-3 {
+    animation: orbFloatC 26s ease-in-out infinite;
+  }
+
+  /* Disable particle animations (filter + background-position are paint-heavy) */
   .bg-particles-1,
   .bg-particles-2 {
-    opacity: 0.5;
+    animation: none;
+    will-change: auto;
+    opacity: 0.32;
+    filter: none;
   }
 
+  /* Static wave — no animation, reduced blur */
   .bg-wave {
-    opacity: 0.26;
+    animation: none;
+    opacity: 0.18;
+    filter: blur(46px);
   }
 }
 
@@ -553,13 +586,16 @@ body {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  filter: drop-shadow(0 2px 12px rgba(37, 99, 235, 0.3));
+  letter-spacing: -0.03em;
 }
 
 .hero .subtitle {
   font-size: clamp(1.1rem, 2vw, 1.5rem);
   color: var(--text-secondary);
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
   font-weight: 400;
+  letter-spacing: -0.01em;
 }
 
 .hero-badges {
@@ -646,26 +682,44 @@ body {
 }
 
 .section {
-  margin: 4rem 0;
+  margin: 5rem 0;
   animation: fadeInUp 0.8s ease-out;
 }
 
 .section-title {
   font-size: clamp(2rem, 4vw, 3rem);
   font-weight: 800;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
   background: var(--gradient-2);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
   display: inline-block;
+  position: relative;
+  letter-spacing: -0.025em;
+  filter: drop-shadow(0 1px 8px rgba(37, 99, 235, 0.2));
+}
+
+.section-title::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 48px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--gradient-2);
+  opacity: 0.7;
 }
 
 .section-subtitle {
-  font-size: 1.2rem;
+  font-size: 1.15rem;
   color: var(--text-secondary);
-  margin-bottom: 2rem;
+  margin-bottom: 2.5rem;
+  margin-top: 0.75rem;
   max-width: 800px;
+  line-height: 1.7;
 }
 
 /* Cards */
@@ -686,6 +740,10 @@ body {
   transition: border-color 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.card + .card {
+  margin-top: 1.5rem;
+}
+
 .card:hover {
   border-color: var(--primary-color);
 }
@@ -697,10 +755,11 @@ body {
 }
 
 .card h3 {
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   font-weight: 700;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.85rem;
   color: var(--text-primary);
+  letter-spacing: -0.01em;
 }
 
 .card p {
@@ -819,7 +878,138 @@ body {
   justify-content: center;
 }
 
-/* Code Blocks */
+/* macOS-style Code Window */
+.code-window {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  margin: 1rem 0;
+  background: #1a1b26;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.35),
+    0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.code-window-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.7rem 1rem;
+  background: linear-gradient(180deg, #2e2f3e 0%, #282935 100%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  user-select: none;
+}
+
+.code-window-dots {
+  display: flex;
+  gap: 7px;
+  flex-shrink: 0;
+}
+
+.code-window-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  transition: filter 0.2s ease;
+}
+
+.code-window:hover .code-window-dot {
+  filter: brightness(1.15);
+}
+
+.code-window-dot--close {
+  background: #ff5f57;
+  box-shadow: inset 0 -1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.code-window-dot--minimize {
+  background: #febc2e;
+  box-shadow: inset 0 -1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.code-window-dot--maximize {
+  background: #28c840;
+  box-shadow: inset 0 -1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.code-window-title {
+  flex: 1;
+  text-align: center;
+  font-size: 0.78rem;
+  color: rgba(248, 250, 252, 0.45);
+  font-family: 'Inter', -apple-system, sans-serif;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.code-window .copy-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.28rem 0.65rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(248, 250, 252, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.375rem;
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-family: 'Inter', -apple-system, sans-serif;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  line-height: 1;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.code-window .copy-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(248, 250, 252, 0.85);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.code-window .copy-btn.copied {
+  background: rgba(16, 185, 129, 0.15);
+  color: #34d399;
+  border-color: rgba(16, 185, 129, 0.3);
+}
+
+.code-window pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  padding: 1.25rem 1.5rem;
+  overflow-x: auto;
+}
+
+.code-window pre::-webkit-scrollbar {
+  height: 6px;
+}
+
+.code-window pre::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.code-window pre::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+.code-window pre::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.code-window code {
+  font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
+  font-size: 0.855rem;
+  color: #c0caf5;
+  line-height: 1.7;
+}
+
+/* Fallback for unstyled pre/code (e.g. inside mermaid) */
 pre {
   background: var(--dark-card);
   border: 1px solid var(--dark-border);
@@ -833,6 +1023,25 @@ code {
   font-family: 'Fira Code', 'Consolas', monospace;
   font-size: 0.9rem;
   color: var(--text-primary);
+}
+
+@media (max-width: 768px) {
+  .code-window pre {
+    padding: 1rem;
+  }
+
+  .code-window code {
+    font-size: 0.78rem;
+  }
+
+  .code-window-dot {
+    width: 10px;
+    height: 10px;
+  }
+
+  .code-window-title {
+    font-size: 0.72rem;
+  }
 }
 
 /* Tables */


### PR DESCRIPTION
- Reduce background animation intensity on mobile (≤768px) to fix lag: disable particle/wave/grid animations, slow aurora, remove orb glow
- Style code blocks as macOS-style windows with traffic-light dots, title bar with auto-detected labels, and SVG copy button
- Improve hero h1 and section titles with drop-shadow glow, tighter letter-spacing, and gradient accent underline on section headings
- Add spacing between consecutive cards (Key Features section fix)
- Increase section margin and subtitle line-height for better rhythm